### PR TITLE
Req 3: THD measurement — IIR filter output, pass < 1%

### DIFF
--- a/Docs/requirements/3-thd/test_thd.py
+++ b/Docs/requirements/3-thd/test_thd.py
@@ -181,6 +181,8 @@ def main():
 
 	# --- Identify harmonics 2–N ---
 	harmonic_v2 = []
+	THRESHOLD_DB = -80.0   # must match :FUNC1:FFT:SEAR:THR value above
+
 	for h in range(2, N_HARMONICS + 1):
 		expected = FUND_FREQ * h
 		candidates = [(f, a) for f, a in peaks
@@ -192,7 +194,8 @@ def main():
 			print(f'  Harmonic {h:2d}: {hf:7.1f} Hz  {ha:+.2f} dBVrms  '
 			      f'({ha - fund_db:+.1f} dBc)')
 		else:
-			print(f'  Harmonic {h:2d}: {expected:7.1f} Hz  — below threshold')
+			print(f'  Harmonic {h:2d}: {expected:7.1f} Hz  '
+			      f'< {THRESHOLD_DB:.0f} dBVrms  (below threshold)')
 
 	# --- Compute THD ---
 	fund_v_rms = 10.0 ** (fund_db / 20.0)


### PR DESCRIPTION
## Summary

- No firmware changes — measurement only
- Configures FY6800: 200 Hz sine, 1.0 Vpp, 1.65 V offset
- Scope C1 + C2: AC coupled, 200 mV/div (fixed, no rescaling)
- FUNC1 FFT on C2: FlatTop window, 4000 Hz span, 2M points, left on screen
- Peak search at −60 dBVrms threshold; harmonics 2–10 identified
- THD computed as sqrt(ΣVh²) / V1 × 100%

Closes #7

## Test plan

- [ ] Run `python3 Docs/requirements/3-thd/test_thd.py`
- [ ] Confirm fundamental found at 200 Hz
- [ ] Confirm harmonics table printed
- [ ] Confirm `PASS  (limit: 1 %)` printed
- [ ] Confirm FFT remains visible on scope screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)