### PR TITLE
Req 4: Step response — 50 Hz square wave, verify overshoot and DC gain

### DIFF
--- a/Docs/requirements/2-iir-filter/test_bode.py
+++ b/Docs/requirements/2-iir-filter/test_bode.py
@@ -169,6 +169,9 @@ def main():
     sc.connect(('192.168.0.87', 5025))
     sc.settimeout(5)
 
+    # Clear any FFT overlay left by a previous test
+    scope_send(sc, ':FUNC1 OFF')
+
     # C1 and C2: AC coupled, fixed 200 mV/div — audience sees C2 amplitude
     # visibly dropping as frequency rises without any axis rescaling.
     for ch in ('C1', 'C2'):

--- a/Docs/requirements/4-step-response/test_step.py
+++ b/Docs/requirements/4-step-response/test_step.py
@@ -107,6 +107,9 @@ def main():
 	sc.connect(('192.168.0.87', 5025))
 	sc.settimeout(5)
 
+	# Clear any FFT overlay left by a previous test
+	scope_send(sc, ':FUNC1 OFF')
+
 	# C1 and C2: AC coupled, 200 mV/div
 	for ch in ('C1', 'C2'):
 		scope_send(sc, f'{ch}:ATTN 10')


### PR DESCRIPTION
## Summary

- FY6800: 50 Hz square wave, 1.0 Vpp, 1.65 V offset
- Scope C1 + C2: AC coupled, 200 mV/div, 1 ms/div, triggered on C1 rising edge
- Overshoot computed from C2 MAX and AMPL: `(MAX − AMPL/2) / AMPL × 100`
- DC gain: C2 AMPL / C1 AMPL

Closes #9

## Test plan

- [ ] Run `python3 Docs/requirements/4-step-response/test_step.py`
- [ ] Confirm overshoot printed ~4.3 %
- [ ] Confirm DC gain ~1.0
- [ ] Confirm `PASS` printed

🤖 Generated with [Claude Code](https://claude.com/claude-code)