### PR TITLE
Req 1: Peripheral Pinout

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -49,7 +49,10 @@
 void SystemClock_Config(void);
 static void MX_GPIO_Init(void);
 /* USER CODE BEGIN PFP */
-
+static void filter_periph_init(void);
+static void adc_init(void);
+static void dac_init(void);
+static void tim6_init(void);
 /* USER CODE END PFP */
 
 /* Private user code ---------------------------------------------------------*/
@@ -87,7 +90,7 @@ int main(void)
   /* Initialize all configured peripherals */
   MX_GPIO_Init();
   /* USER CODE BEGIN 2 */
-
+  filter_periph_init();
   /* USER CODE END 2 */
 
   /* Infinite loop */
@@ -167,6 +170,113 @@ static void MX_GPIO_Init(void)
 }
 
 /* USER CODE BEGIN 4 */
+
+/*
+ * filter_periph_init — top-level peripheral initialisation for the filter signal path.
+ * Called once from main() after SystemClock_Config and MX_GPIO_Init.
+ */
+static void filter_periph_init(void)
+{
+	adc_init();
+	dac_init();
+	tim6_init();
+}
+
+/*
+ * adc_init — configure ADC1 channel 1 (PA0) for software-triggered single conversion.
+ *
+ * Clock: synchronous HCLK/4 (42 MHz) via ADC12_COMMON CCR CKMODE=0b11.
+ * Resolution: 12-bit.  Sampling time: 6.5 ADC cycles → total conversion 19 cycles = 452 ns.
+ * Enable sequence per RM0440 §21.4.6: ADVREGEN → wait 20 µs → ADCAL → ADEN → ADRDY.
+ */
+static void adc_init(void)
+{
+	/* Enable ADC12 clock on AHB2 */
+	RCC->AHB2ENR |= RCC_AHB2ENR_ADC12EN;
+
+	/* PA0 to analogue mode (MODER bits 1:0 = 0b11) */
+	GPIOA->MODER |= (3U << (0 * 2));
+
+	/* ADC12 common clock: synchronous HCLK/4 (CKMODE = 0b11) */
+	ADC12_COMMON->CCR = (3U << ADC_CCR_CKMODE_Pos);
+
+	/* Exit deep power-down, enable voltage regulator */
+	ADC1->CR &= ~ADC_CR_DEEPPWD;
+	ADC1->CR |= ADC_CR_ADVREGEN;
+
+	/* Wait ≥20 µs for regulator start-up (1 ms via HAL tick) */
+	HAL_Delay(1);
+
+	/* Calibrate (single-ended: ADCALDIF = 0) */
+	ADC1->CR |= ADC_CR_ADCAL;
+	while (ADC1->CR & ADC_CR_ADCAL)
+	{
+	}
+
+	/* Enable ADC */
+	ADC1->CR |= ADC_CR_ADEN;
+	while (!(ADC1->ISR & ADC_ISR_ADRDY))
+	{
+	}
+
+	/* Configure: 12-bit, software trigger, single conversion */
+	ADC1->CFGR = 0;	/* CONT=0, EXTEN=00, RES=00 (12-bit) */
+
+	/* Sequence: 1 conversion, channel 1 (PA0 = IN1) */
+	ADC1->SQR1 = (1U << ADC_SQR1_SQ1_Pos);
+
+	/* Sampling time for channel 1: 6.5 ADC cycles (SMP1 = 0b001) */
+	ADC1->SMPR1 = (1U << ADC_SMPR1_SMP1_Pos);
+}
+
+/*
+ * dac_init — configure DAC1 channel 1 (PA4) in software-trigger mode.
+ *
+ * DAC1 is on AHB2.  Output is written directly to DHR12R1 by the ISR.
+ * PA4 MODER set to analogue to connect pin to DAC output buffer.
+ */
+static void dac_init(void)
+{
+	/* Enable DAC1 clock on AHB2 */
+	RCC->AHB2ENR |= RCC_AHB2ENR_DAC1EN;
+
+	/* PA4 to analogue mode (MODER bits 9:8 = 0b11) */
+	GPIOA->MODER |= (3U << (4 * 2));
+
+	/* Enable DAC1 channel 1 (no hardware trigger, output buffer enabled) */
+	DAC1->CR = DAC_CR_EN1;
+}
+
+/*
+ * tim6_init — configure TIM6 to fire an update interrupt at exactly 8 kHz.
+ *
+ * f = PCLK1 / ((PSC+1) * (ARR+1)) = 168 000 000 / (1 * 21 000) = 8 000 Hz.
+ * IRQ is shared with DAC underrun; handler name: TIM6_DAC_IRQHandler.
+ */
+static void tim6_init(void)
+{
+	/* Enable TIM6 clock on APB1 */
+	RCC->APB1ENR1 |= RCC_APB1ENR1_TIM6EN;
+
+	/* PSC=0, ARR=20999 → 168 MHz / 21000 = 8000 Hz */
+	TIM6->PSC = 0;
+	TIM6->ARR = 20999;
+
+	/* Generate an update event to load PSC and ARR into shadow registers */
+	TIM6->EGR = TIM_EGR_UG;
+
+	/* Clear the update flag set by the UG event above */
+	TIM6->SR = 0;
+
+	/* Enable update interrupt */
+	TIM6->DIER = TIM_DIER_UIE;
+
+	/* Enable TIM6_DAC IRQ in NVIC at default priority */
+	NVIC_EnableIRQ(TIM6_DAC_IRQn);
+
+	/* Start counter */
+	TIM6->CR1 = TIM_CR1_CEN;
+}
 
 /* USER CODE END 4 */
 

--- a/Core/Src/stm32g4xx_it.c
+++ b/Core/Src/stm32g4xx_it.c
@@ -200,4 +200,28 @@ void SysTick_Handler(void)
 
 /* USER CODE BEGIN 1 */
 
+/*
+ * TIM6_DAC_IRQHandler — 8 kHz sample ISR.
+ *
+ * Reads one 12-bit sample from ADC1 and writes it straight to DAC1 CH1
+ * (pass-through, no filtering).  The shared TIM6/DAC IRQ name is required
+ * by the STM32G4 vector table.
+ */
+void TIM6_DAC_IRQHandler(void)
+{
+	/* Clear TIM6 update interrupt flag */
+	TIM6->SR &= ~TIM_SR_UIF;
+
+	/* Start single software-triggered ADC conversion */
+	ADC1->CR |= ADC_CR_ADSTART;
+
+	/* Wait for end of conversion */
+	while (!(ADC1->ISR & ADC_ISR_EOC))
+	{
+	}
+
+	/* Read result (clears EOC flag) and pass straight to DAC */
+	DAC1->DHR12R1 = ADC1->DR;
+}
+
 /* USER CODE END 1 */

--- a/Docs/requirements/1-peripheral-pinout/test_passthrough.py
+++ b/Docs/requirements/1-peripheral-pinout/test_passthrough.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Req 1 — Peripheral Pinout: pass-through verification.
+
+Stimulates the MCU with a 100 Hz sine at 1.0 Vpp via FY6800 CH1 and measures
+the peak-to-peak voltage on both scope channels.  Checks that the ADC→DAC
+pass-through ratio is within ±20% of unity.
+
+Hardware required:
+  - FY6800 CH1 → PA0 (100 Ω series protection resistor recommended)
+  - PA4 → 4.7 kΩ → scope C2 probe tip; 10 nF from junction to GND
+  - Scope C1 probe on FY6800 output
+  - Both probe grounds connected to system GND
+"""
+
+import socket
+import time
+import re
+import serial
+import sys
+
+# ── Instrument addresses ─────────────────────────────────────────────────────
+FY6800_PORT   = '/dev/ttyUSB0'
+SCOPE_IP      = '192.168.0.87'
+SCOPE_PORT    = 5025
+
+# ── Test parameters ───────────────────────────────────────────────────────────
+FREQ_HZ       = 100
+AMP_VPP       = 1.0
+OFFSET_V      = 1.65
+RATIO_MIN     = 0.80
+RATIO_MAX     = 1.20
+
+
+# ── FY6800 helper ─────────────────────────────────────────────────────────────
+class FY6800:
+    def __init__(self, port=FY6800_PORT):
+        self.s = serial.Serial(port, 115200, timeout=1)
+        time.sleep(0.5)
+
+    def _cmd(self, c, wait=0.15):
+        self.s.write((c + '\n').encode())
+        time.sleep(wait)
+        return self.s.read_all().decode(errors='replace').strip()
+
+    def set_wave(self, ch, code):
+        pfx = 'M' if ch == 0 else 'F'
+        self._cmd(f'W{pfx}W{code:02d}')
+
+    def set_freq(self, ch, hz):
+        pfx = 'M' if ch == 0 else 'F'
+        uhz = int(hz * 1_000_000)
+        self._cmd(f'W{pfx}F{uhz:014d}')
+
+    def set_amp(self, ch, v):
+        pfx = 'M' if ch == 0 else 'F'
+        self._cmd(f'W{pfx}A{v:.4f}')
+
+    def set_offset(self, ch, v):
+        pfx = 'M' if ch == 0 else 'F'
+        self._cmd(f'W{pfx}O{v:.4f}')
+
+    def output(self, ch, on):
+        pfx = 'M' if ch == 0 else 'F'
+        self._cmd(f'W{pfx}N{1 if on else 0}')
+
+    def close(self):
+        self.s.close()
+
+
+# ── Scope helper ──────────────────────────────────────────────────────────────
+class Scope:
+    def __init__(self, ip=SCOPE_IP, port=SCOPE_PORT):
+        self.s = socket.socket()
+        self.s.connect((ip, port))
+        self.s.settimeout(5)
+
+    def send(self, cmd):
+        self.s.sendall((cmd + '\n').encode())
+        time.sleep(0.15)
+
+    def query(self, cmd, delay=1.0):
+        self.s.sendall((cmd + '\n').encode())
+        time.sleep(delay)
+        try:
+            return self.s.recv(65536).decode(errors='replace').strip()
+        except Exception:
+            return ''
+
+    def pkpk(self, ch):
+        raw = self.query(f'C{ch}:PAVA? PKPK', delay=0.5)
+        m = re.search(r'PKPK,([0-9.E+\-]+)V', raw)
+        if not m:
+            raise RuntimeError(f'Could not parse PKPK from: {raw!r}')
+        return float(m.group(1))
+
+    def close(self):
+        self.s.close()
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+def main():
+    print('=== Req 1: Pass-through verification ===')
+
+    print(f'Configuring FY6800 CH1: {FREQ_HZ} Hz sine, {AMP_VPP} Vpp, '
+          f'{OFFSET_V} V offset …')
+    fy = FY6800()
+    fy.set_wave(0, 0)
+    fy.set_freq(0, FREQ_HZ)
+    fy.set_amp(0, AMP_VPP)
+    fy.set_offset(0, OFFSET_V)
+    fy.output(0, True)
+    fy.close()
+    print('  FY6800 configured.')
+
+    print('Configuring scope …')
+    sc = Scope()
+    sc.send(':FUNC1 OFF')
+
+    for ch in (1, 2):
+        sc.send(f'C{ch}:ATTN 10')
+        sc.send(f'C{ch}:CPL A1M')
+        sc.send(f'C{ch}:VDIV 200E-3')
+        sc.send(f'C{ch}:OFST 0')
+
+    sc.send('TDIV 5E-3')
+    sc.send('TRMD AUTO')
+    time.sleep(2.0)
+
+    print('Measuring …')
+    v_in  = sc.pkpk(1)
+    v_out = sc.pkpk(2)
+    sc.close()
+
+    ratio = v_out / v_in if v_in > 0 else 0.0
+
+    print(f'  C1 Vpp (input)  = {v_in*1000:.1f} mV')
+    print(f'  C2 Vpp (output) = {v_out*1000:.1f} mV')
+    print(f'  Ratio Vout/Vin  = {ratio:.3f}')
+
+    if RATIO_MIN <= ratio <= RATIO_MAX:
+        print(f'\n  PASS  ({RATIO_MIN} ≤ {ratio:.3f} ≤ {RATIO_MAX})')
+        sys.exit(0)
+    else:
+        print(f'\n  FAIL  ratio {ratio:.3f} outside [{RATIO_MIN}, {RATIO_MAX}]')
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Implements #17

## Summary
- Bare-metal init for ADC1/PA0, DAC1/PA4, and TIM6 at 8 kHz in static functions called from `USER CODE BEGIN 2`
- TIM6 update ISR reads ADC and writes straight to DAC — pass-through, no filtering yet
- Verification script measures PKPK ratio at 100 Hz (pass: 0.8–1.2)

## Test plan
- [x] Built via `make all` from WSL2
- [x] Flashed via `STM32_Programmer_CLI.exe` from WSL2
- [ ] Verify script passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)